### PR TITLE
Adding windows-GNU to appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     RUST_VERSION: stable
     matrix:
         - TARGET: x86_64-pc-windows-msvc
+        - TARGET: x86_64-pc-windows-gnu
 
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/


### PR DESCRIPTION
This adds the `windows-gnu`-dimension to the appveyor build matrix to ensure sass-sys always works with both (GNU and ms) build environments.